### PR TITLE
feat: add email-based OTP authentication for Telegram bots with SMTP support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,9 @@ BACKEND_CORS_ORIGINS=["http://localhost:${FRONTEND_PORT}"]
 NEXT_PUBLIC_API_URL=http://localhost:${BACKEND_PORT}/api/v1
 
 # ----------- SMTP -------------------
-SMTP_HOST=mailpit
-SMTP_PORT=1025
-SMTP_FROM=no-reply@example.local
-SMTP_STARTTLS=false
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USERNAME=apikey           # or your SMTP username from provider
+SMTP_PASSWORD=SG.xxxxxxx       # the actual password or API key
+SMTP_FROM=no-reply@yourdomain.com
+SMTP_STARTTLS=true

--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,9 @@ REDIS_URL=redis://redis:6379/0
 # ---------- CORS & Front-end -----------------------
 BACKEND_CORS_ORIGINS=["http://localhost:${FRONTEND_PORT}"]
 NEXT_PUBLIC_API_URL=http://localhost:${BACKEND_PORT}/api/v1
+
+# ----------- SMTP -------------------
+SMTP_HOST=mailpit
+SMTP_PORT=1025
+SMTP_FROM=no-reply@example.local
+SMTP_STARTTLS=false

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,9 +16,9 @@ BACKEND_CORS_ORIGINS=["http://localhost:3000","http://frontend:3000"]
 TELEGRAM_WEBHOOK_URL=https://your-domain.com/webhooks/telegram
 
 # SMTP
-SMTP_HOST=smtp.yourprovider.com
+SMTP_HOST=smtp.sendgrid.net
 SMTP_PORT=587
-SMTP_USERNAME=your_smtp_user
-SMTP_PASSWORD=your_smtp_pass
-SMTP_FROM=plugbot@yourdomain.com
+SMTP_USERNAME=apikey           # or your SMTP username from provider
+SMTP_PASSWORD=SG.xxxxxxx       # the actual password or API key
+SMTP_FROM=no-reply@yourdomain.com
 SMTP_STARTTLS=true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,3 +14,11 @@ BACKEND_CORS_ORIGINS=["http://localhost:3000","http://frontend:3000"]
 
 # Telegram (optional, can be set per bot)
 TELEGRAM_WEBHOOK_URL=https://your-domain.com/webhooks/telegram
+
+# SMTP
+SMTP_HOST=smtp.yourprovider.com
+SMTP_PORT=587
+SMTP_USERNAME=your_smtp_user
+SMTP_PASSWORD=your_smtp_pass
+SMTP_FROM=plugbot@yourdomain.com
+SMTP_STARTTLS=true

--- a/backend/alembic/versions/002.py
+++ b/backend/alembic/versions/002.py
@@ -1,0 +1,31 @@
+"""Remove temperature and max_tokens columns
+
+Revision ID: 002
+Revises: 001
+Create Date: 2025-01-08 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers
+revision = '002'
+down_revision = '001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop temperature and max_tokens columns from bots table
+    op.drop_column('bots', 'temperature')
+    op.drop_column('bots', 'max_tokens')
+
+
+def downgrade() -> None:
+    # Re-add columns if rolling back
+    op.add_column('bots',
+                  sa.Column('temperature', sa.Integer(), server_default='7', nullable=True)
+                  )
+    op.add_column('bots',
+                  sa.Column('max_tokens', sa.Integer(), server_default='2000', nullable=True)
+                  )

--- a/backend/alembic/versions/003_add_auth_codes.py
+++ b/backend/alembic/versions/003_add_auth_codes.py
@@ -1,0 +1,37 @@
+"""add auth_codes table
+Revision ID: 003
+Revises: 002
+Create Date: 2025-08-08 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "auth_codes",
+        sa.Column("id", sa.String(), primary_key=True, nullable=False),
+        sa.Column("bot_id", sa.String(), sa.ForeignKey("bots.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("code", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("is_used", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+    )
+    op.create_index("ix_auth_codes_bot_id", "auth_codes", ["bot_id"])
+    op.create_index("ix_auth_codes_email", "auth_codes", ["email"])
+    op.create_index("ix_auth_codes_code", "auth_codes", ["code"])
+
+
+def downgrade():
+    op.drop_index("ix_auth_codes_code", table_name="auth_codes")
+    op.drop_index("ix_auth_codes_email", table_name="auth_codes")
+    op.drop_index("ix_auth_codes_bot_id", table_name="auth_codes")
+    op.drop_table("auth_codes")

--- a/backend/alembic/versions/004_add_auth_fields_to_bots.py
+++ b/backend/alembic/versions/004_add_auth_fields_to_bots.py
@@ -1,0 +1,30 @@
+"""add auth_required and allowed_email_domains to bots
+
+Revision ID: 004
+Revises: 003
+Create Date: 2025-08-08 20:05:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "004"
+down_revision = "003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "bots",
+        sa.Column("auth_required", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+    op.add_column(
+        "bots",
+        sa.Column("allowed_email_domains", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("bots", "allowed_email_domains")
+    op.drop_column("bots", "auth_required")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -49,6 +49,14 @@ class Settings(BaseSettings):
     # Encryption for sensitive data
     ENCRYPTION_KEY: str = Field(..., env="ENCRYPTION_KEY")
 
+    # SMTP (for email-based auth codes)
+    SMTP_HOST: str | None = Field(default=None, env="SMTP_HOST")
+    SMTP_PORT: int = Field(default=587, env="SMTP_PORT")
+    SMTP_USERNAME: str | None = Field(default=None, env="SMTP_USERNAME")
+    SMTP_PASSWORD: str | None = Field(default=None, env="SMTP_PASSWORD")
+    SMTP_FROM: str = Field(default="no-reply@yourdomain.com", env="SMTP_FROM")
+    SMTP_STARTTLS: bool = Field(default=True, env="SMTP_STARTTLS")
+
     class Config:
         env_file = ".env"
         case_sensitive = True

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,3 @@
+from .bot import Bot
+from .conversation import Conversation, Message
+from .auth import AuthCode

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, String, DateTime, Boolean, ForeignKey
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from ..core.database import Base
+import uuid
+
+
+class AuthCode(Base):
+    __tablename__ = "auth_codes"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    bot_id = Column(String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False)
+
+    email = Column(String(255), nullable=False)
+    code = Column(String(64), nullable=False)  # one-time code
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    used_at = Column(DateTime(timezone=True))
+    is_used = Column(Boolean, default=False)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    # Relationships
+    bot = relationship("Bot", back_populates="auth_codes")

--- a/backend/app/models/bot.py
+++ b/backend/app/models/bot.py
@@ -32,10 +32,12 @@ class Bot(Base):
 
     # Settings
     response_mode = Column(String(20), default="streaming")  # streaming or blocking
-    max_tokens = Column(Integer, default=2000)
-    temperature = Column(Integer, default=7)  # 0-10, will be divided by 10
     auto_generate_title = Column(Boolean, default=True)
     enable_file_upload = Column(Boolean, default=True)
+
+    # Authentication Settings (New)
+    auth_required = Column(Boolean, default=False)
+    allowed_email_domains = Column(Text)  # Comma-separated list of domains
 
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())
@@ -43,3 +45,4 @@ class Bot(Base):
 
     # Relationships
     conversations = relationship("Conversation", back_populates="bot", cascade="all, delete-orphan")
+    auth_codes = relationship("AuthCode", back_populates="bot", cascade="all, delete-orphan")

--- a/backend/app/schemas/bot.py
+++ b/backend/app/schemas/bot.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, field_validator
-from typing import Optional
+from typing import Optional, List
 from datetime import datetime
 
 
@@ -10,10 +10,12 @@ class BotBase(BaseModel):
     dify_endpoint: str = Field(..., min_length=1)
     dify_type: str = Field(default="chat", pattern="^(chat|agent|chatflow|workflow)$")
     response_mode: str = Field(default="streaming", pattern="^(streaming|blocking)$")
-    max_tokens: int = Field(default=2000, ge=100, le=10000)
-    temperature: int = Field(default=7, ge=0, le=10)
     auto_generate_title: bool = True
     enable_file_upload: bool = True
+
+    # Authentication settings
+    auth_required: bool = False
+    allowed_email_domains: Optional[str] = None  # Comma-separated domains like "algolyzer.com,google.com"
 
 
 class BotCreate(BotBase):
@@ -42,6 +44,21 @@ class BotCreate(BotBase):
         # Treat empty string as None
         return v or None
 
+    @field_validator('allowed_email_domains')
+    def validate_email_domains(cls, v: Optional[str]):
+        if v is None or v.strip() == '':
+            return None
+        # Clean and validate domain format
+        domains = [d.strip().lower() for d in v.split(',')]
+        for domain in domains:
+            if not domain:
+                continue
+            # Remove @ if present and validate basic domain format
+            domain = domain.lstrip('@')
+            if '.' not in domain or len(domain) < 3:
+                raise ValueError(f'Invalid domain format: {domain}')
+        return ','.join(domains)
+
 
 class BotUpdate(BaseModel):
     """Schema for updating a bot."""
@@ -52,13 +69,12 @@ class BotUpdate(BaseModel):
     dify_type: Optional[str] = Field(None, pattern="^(chat|agent|chatflow|workflow)$")
     telegram_bot_token: Optional[str] = None
     response_mode: Optional[str] = Field(None, pattern="^(streaming|blocking)$")
-    max_tokens: Optional[int] = Field(None, ge=100, le=10000)
-    temperature: Optional[int] = Field(None, ge=0, le=10)
     auto_generate_title: Optional[bool] = None
     enable_file_upload: Optional[bool] = None
     is_active: Optional[bool] = None
+    auth_required: Optional[bool] = None
+    allowed_email_domains: Optional[str] = None
 
-    # Normalize/guard against accidental erasure of secrets
     @field_validator('dify_endpoint')
     def normalize_endpoint(cls, v: Optional[str]):
         if v is None:
@@ -74,6 +90,19 @@ class BotUpdate(BaseModel):
             if v == '':
                 return None
         return v
+
+    @field_validator('allowed_email_domains')
+    def validate_email_domains(cls, v: Optional[str]):
+        if v is None or v.strip() == '':
+            return None
+        domains = [d.strip().lower() for d in v.split(',')]
+        for domain in domains:
+            if not domain:
+                continue
+            domain = domain.lstrip('@')
+            if '.' not in domain or len(domain) < 3:
+                raise ValueError(f'Invalid domain format: {domain}')
+        return ','.join(domains)
 
 
 class BotResponse(BotBase):

--- a/backend/app/services/telegram_service.py
+++ b/backend/app/services/telegram_service.py
@@ -1,15 +1,40 @@
+from __future__ import annotations
+
+import json
+import re
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Optional, List
+
+import redis
+from sqlalchemy.orm import Session
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.ext import Application, CommandHandler, MessageHandler, filters, CallbackQueryHandler
 from telegram.constants import ParseMode, ChatAction
 from telegram.error import BadRequest
-from typing import Optional
-from datetime import datetime
-from sqlalchemy.orm import Session
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    MessageHandler,
+    CallbackQueryHandler,
+    filters,
+)
+
+from ..core.config import settings
+from ..core.security import security_manager
 from ..models.bot import Bot
 from ..models.conversation import Conversation, Message
-from ..core.security import security_manager
+from ..models.auth import AuthCode
 from ..services.dify_service import DifyService
 from ..utils.logger import get_logger
+
+# Optional helper (you should add backend/app/utils/mailer.py as discussed)
+try:
+    from ..utils.mailer import send_email  # send_email(to_email, subject, body)
+except Exception:  # pragma: no cover
+    def send_email(to_email: str, subject: str, body: str):
+        raise RuntimeError(
+            "Email sender not configured. Provide app/utils/mailer.py and SMTP env."
+        )
 
 logger = get_logger(__name__)
 
@@ -18,63 +43,124 @@ class TelegramService:
     """Service for managing Telegram bot integration."""
 
     def __init__(self, bot: Bot, db: Session):
-        self.bot = bot
+        self._bot = bot
         self.db = db
         self.token = security_manager.decrypt_data(bot.telegram_bot_token)
         self.application: Optional[Application] = None
         self.dify_service = DifyService(bot)
         self.running = False
+        # Redis for lightweight session of "who is authenticated"
+        self.redis = redis.Redis.from_url(settings.REDIS_URL, decode_responses=True)
 
-    async def initialize(self):
+    @property
+    def bot(self) -> Bot:
+        return self._bot
+
+    # ---------- AUTH HELPERS ----------
+
+    def _auth_key(self, telegram_user_id: str) -> str:
+        return f"auth:{self.bot.id}:{telegram_user_id}"
+
+    def _pending_key(self, telegram_user_id: str) -> str:
+        return f"pending:{self.bot.id}:{telegram_user_id}"
+
+    def _is_authenticated(self, telegram_user_id: str) -> bool:
+        return self.redis.exists(self._auth_key(telegram_user_id)) == 1
+
+    def _set_authenticated(self, telegram_user_id: str, email: str):
+        self.redis.set(self._auth_key(telegram_user_id), json.dumps({"email": email}))
+        # Persist until /logout (no TTL)
+
+    def _clear_authenticated(self, telegram_user_id: str):
+        self.redis.delete(self._auth_key(telegram_user_id))
+        self.redis.delete(self._pending_key(telegram_user_id))
+
+    def _allowed_domains(self) -> List[str]:
+        if not self.bot.allowed_email_domains:
+            return []
+        return [
+            d.strip().lstrip("@").lower()
+            for d in self.bot.allowed_email_domains.split(",")
+            if d.strip()
+        ]
+
+    def _email_ok_for_bot(self, email: str) -> bool:
+        allowed = self._allowed_domains()
+        if not allowed:
+            return True
+        if "@" not in email:
+            return False
+        domain = email.split("@", 1)[1].lower()
+        return domain in allowed
+
+    def _looks_like_email(self, text: str) -> bool:
+        return bool(
+            re.fullmatch(
+                r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}", text.strip()
+            )
+        )
+
+    # ---------- LIFECYCLE ----------
+
+    async def initialize(self) -> bool:
         """Initialize Telegram bot."""
         try:
             self.application = Application.builder().token(self.token).build()
 
-            # Add handlers
+            # Commands & handlers
             self.application.add_handler(CommandHandler("start", self.handle_start))
             self.application.add_handler(CommandHandler("help", self.handle_help))
             self.application.add_handler(CommandHandler("new", self.handle_new_conversation))
             self.application.add_handler(CommandHandler("clear", self.handle_clear))
             self.application.add_handler(CommandHandler("history", self.handle_history))
-            self.application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self.handle_message))
+            self.application.add_handler(CommandHandler("logout", self.handle_logout))
+
+            # Messages
+            self.application.add_handler(
+                MessageHandler(filters.TEXT & ~filters.COMMAND, self.handle_message)
+            )
             self.application.add_handler(MessageHandler(filters.Document.ALL, self.handle_document))
             self.application.add_handler(MessageHandler(filters.PHOTO, self.handle_photo))
+
+            # Callback buttons
             self.application.add_handler(CallbackQueryHandler(self.handle_callback))
 
-            # Initialize bot
             await self.application.initialize()
-            await self.application.bot.set_my_commands([
-                ("start", "Start the bot"),
-                ("help", "Show help message"),
-                ("new", "Start new conversation"),
-                ("clear", "Clear current conversation"),
-                ("history", "Show conversation history"),
-            ])
+            await self.application.bot.set_my_commands(
+                [
+                    ("start", "Start the bot"),
+                    ("help", "Show help message"),
+                    ("new", "Start a new conversation"),
+                    ("clear", "Clear current conversation"),
+                    ("history", "Show conversation history"),
+                    ("logout", "Log out of this bot"),
+                ]
+            )
 
-            # Do NOT mark running here; polling sets this flag.
-            logger.info(f"Telegram bot {self.bot.name} initialized successfully")
+            logger.info("Telegram bot %s initialized successfully", self.bot.name)
             return True
-
         except Exception as e:
-            logger.error(f"Failed to initialize Telegram bot: {str(e)}")
+            logger.error("Failed to initialize Telegram bot: %s", e)
             return False
 
     async def start_polling(self):
         """Start polling for updates."""
-        if not self.application or self.running:
-            return
-        # Ensure webhook is cleared so polling receives updates
         try:
-            info = await self.application.bot.get_webhook_info()
-            if info and info.url:
-                logger.warning("Webhook set (%s); deleting for polling mode.", info.url)
-                await self.application.bot.delete_webhook(drop_pending_updates=True)
+            # If a webhook was set previously, clear it so polling works
+            try:
+                info = await self.application.bot.get_webhook_info()
+                if info and info.url:
+                    logger.info("Clearing existing webhook: %s", info.url)
+                    await self.application.bot.delete_webhook(drop_pending_updates=True)
+            except Exception as e:
+                logger.warning("Webhook check/delete failed: %s", e)
+
+            await self.application.start()
+            await self.application.updater.start_polling(drop_pending_updates=True)
+            self.running = True
+            logger.info("Started polling for bot %s", self.bot.name)
         except Exception as e:
-            logger.warning("Webhook check/delete failed: %s", e)
-        await self.application.start()
-        await self.application.updater.start_polling(drop_pending_updates=True)
-        self.running = True
-        logger.info(f"Started polling for bot {self.bot.name}")
+            logger.error("Failed to start polling: %s", e)
 
     async def stop(self):
         """Stop the bot."""
@@ -83,7 +169,9 @@ class TelegramService:
             await self.application.stop()
             await self.application.shutdown()
             self.running = False
-            logger.info(f"Stopped bot {self.bot.name}")
+            logger.info("Stopped bot %s", self.bot.name)
+
+    # ---------- COMMANDS ----------
 
     async def handle_start(self, update: Update, context):
         """Handle /start command."""
@@ -94,7 +182,8 @@ class TelegramService:
             "/help - Show this help message\n"
             "/new - Start a new conversation\n"
             "/clear - Clear current conversation\n"
-            "/history - Show recent conversations\n\n"
+            "/history - Show recent conversations\n"
+            "/logout - Log out and re-authenticate\n\n"
             "Just send me a message to start chatting!"
         )
         await update.message.reply_text(welcome_message, parse_mode=ParseMode.MARKDOWN)
@@ -103,18 +192,27 @@ class TelegramService:
         """Handle /help command."""
         await self.handle_start(update, context)
 
+    async def handle_logout(self, update: Update, context):
+        """Handle /logout command: revoke auth and require OTP again."""
+        user_id = str(update.effective_user.id)
+        self._clear_authenticated(user_id)
+        await update.message.reply_text(
+            "✅ You have been logged out. Send your email to authenticate again."
+        )
+
     async def handle_new_conversation(self, update: Update, context):
         """Handle /new command to start new conversation."""
         chat_id = str(update.effective_chat.id)
-        user_id = str(update.effective_user.id)
 
-        # Deactivate existing conversation
-        existing = self.db.query(Conversation).filter(
-            Conversation.telegram_chat_id == chat_id,
-            Conversation.bot_id == self.bot.id,
-            Conversation.is_active == True
-        ).first()
-
+        existing = (
+            self.db.query(Conversation)
+            .filter(
+                Conversation.telegram_chat_id == chat_id,
+                Conversation.bot_id == self.bot.id,
+                Conversation.is_active == True,
+            )
+            .first()
+        )
         if existing:
             existing.is_active = False
             self.db.commit()
@@ -125,10 +223,13 @@ class TelegramService:
         """Handle /history command."""
         chat_id = str(update.effective_chat.id)
 
-        conversations = self.db.query(Conversation).filter(
-            Conversation.telegram_chat_id == chat_id,
-            Conversation.bot_id == self.bot.id
-        ).order_by(Conversation.updated_at.desc()).limit(5).all()
+        conversations = (
+            self.db.query(Conversation)
+            .filter(Conversation.telegram_chat_id == chat_id, Conversation.bot_id == self.bot.id)
+            .order_by(Conversation.updated_at.desc())
+            .limit(5)
+            .all()
+        )
 
         if not conversations:
             await update.message.reply_text("No conversation history found.")
@@ -138,22 +239,163 @@ class TelegramService:
         for conv in conversations:
             status = "🟢" if conv.is_active else "⚪"
             title = conv.title or f"Conversation {conv.created_at.strftime('%Y-%m-%d %H:%M')}"
-            keyboard.append([
-                InlineKeyboardButton(
-                    f"{status} {title}",
-                    callback_data=f"conv_{conv.id}"
-                )
-            ])
+            keyboard.append(
+                [InlineKeyboardButton(f"{status} {title}", callback_data=f"conv_{conv.id}")]
+            )
 
         reply_markup = InlineKeyboardMarkup(keyboard)
-        await update.message.reply_text(
-            "📚 Recent Conversations:",
-            reply_markup=reply_markup
+        await update.message.reply_text("📚 Recent Conversations:", reply_markup=reply_markup)
+
+    async def handle_clear(self, update: Update, context):
+        """Handle /clear: delete current active conversation and its messages."""
+        chat_id = str(update.effective_chat.id)
+        conv = (
+            self.db.query(Conversation)
+            .filter(
+                Conversation.telegram_chat_id == chat_id,
+                Conversation.bot_id == self.bot.id,
+                Conversation.is_active == True,
+            )
+            .first()
         )
+        if not conv:
+            await update.message.reply_text("Nothing to clear. You’re already fresh ✨")
+            return
+        # delete messages then conversation
+        self.db.query(Message).filter(Message.conversation_id == conv.id).delete()
+        self.db.delete(conv)
+        self.db.commit()
+        await update.message.reply_text("🧹 Cleared. Your next message will start a new conversation.")
+
+    # ---------- CALLBACKS ----------
+
+    async def handle_callback(self, update: Update, context):
+        """Handle callback queries from inline keyboards."""
+        query = update.callback_query
+        await query.answer()
+
+        if query.data.startswith("conv_"):
+            conv_id = query.data[5:]
+            conversation = (
+                self.db.query(Conversation).filter(Conversation.id == conv_id).first()
+            )
+
+            if conversation:
+                # Deactivate others for this chat + bot, activate chosen
+                self.db.query(Conversation).filter(
+                    Conversation.telegram_chat_id == conversation.telegram_chat_id,
+                    Conversation.bot_id == self.bot.id,
+                ).update({"is_active": False})
+
+                conversation.is_active = True
+                self.db.commit()
+
+                await query.edit_message_text(
+                    f"✅ Switched to conversation: {conversation.title or 'Untitled'}"
+                )
+
+    # ---------- MESSAGES (AUTH-GATED) ----------
+
+    async def _auth_gate(self, update: Update, context) -> bool:
+        """
+        Returns True if the user is allowed to proceed to Dify.
+        Otherwise, this method replies (prompts/validates) and returns False to stop handling.
+        """
+        if not self.bot.auth_required:
+            return True
+
+        user_id = str(update.effective_user.id)
+        text = (update.message.text or "").strip()
+
+        # Already authenticated?
+        if self._is_authenticated(user_id):
+            return True
+
+        # 6-digit code?
+        if re.fullmatch(r"\d{6}", text):
+            now = datetime.now(timezone.utc)
+            # Only accept codes for this bot, not used, not expired
+            pending_email = self.redis.get(self._pending_key(user_id))
+            q = (
+                self.db.query(AuthCode)
+                .filter(
+                    AuthCode.bot_id == self.bot.id,
+                    AuthCode.is_used == False,
+                    AuthCode.expires_at > now,
+                    AuthCode.code == text,
+                )
+                .order_by(AuthCode.created_at.desc())
+            )
+            if pending_email:
+                q = q.filter(AuthCode.email == pending_email)
+
+            code_row = q.first()
+            if code_row:
+                code_row.is_used = True
+                code_row.used_at = now
+                self.db.commit()
+                self._set_authenticated(user_id, code_row.email)
+                self.redis.delete(self._pending_key(user_id))
+                await update.message.reply_text("✅ Authentication successful! You can now chat.")
+                return True
+            else:
+                await update.message.reply_text(
+                    "❌ Invalid or expired code. Please send your email again."
+                )
+                return False
+
+        # Looks like email? Validate and send code.
+        if self._looks_like_email(text):
+            email = text
+            if not self._email_ok_for_bot(email):
+                domains = ", ".join(self._allowed_domains()) or "(none configured)"
+                await update.message.reply_text(
+                    f"🚫 Email not allowed. Allowed domains: {domains}"
+                )
+                return False
+
+            # Generate and store 6-digit code, 5 minutes expiry
+            code = f"{secrets.randbelow(1_000_000):06d}"
+            expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+            ac = AuthCode(bot_id=self.bot.id, email=email, code=code, expires_at=expires_at)
+            self.db.add(ac)
+            self.db.commit()
+
+            # Remember pending email per user for strict matching
+            self.redis.setex(self._pending_key(user_id), 300, email)
+
+            try:
+                send_email(
+                    to_email=email,
+                    subject=f"Your {self.bot.name} verification code",
+                    body=f"Your verification code is: {code}\nIt expires in 5 minutes.",
+                )
+            except Exception as e:
+                logger.error("Failed to send code to %s: %s", email, e)
+                await update.message.reply_text(
+                    "❌ Could not send email. Please try again later."
+                )
+                return False
+
+            await update.message.reply_text(
+                "📧 I’ve emailed you a 6-digit code. Reply here with the code to continue (expires in 5 minutes)."
+            )
+            return False
+
+        # Not a code and not an email → prompt
+        domains = self._allowed_domains()
+        hint = f" (allowed domains: {', '.join(domains)})" if domains else ""
+        await update.message.reply_text(f"🔐 Please send your email to authenticate{hint}.")
+        return False
 
     async def handle_message(self, update: Update, context):
-        """Handle text messages."""
+        """Handle text messages (auth-gated before reaching Dify)."""
         if not update.message or not update.message.text:
+            return
+
+        # AUTH GATE
+        can_proceed = await self._auth_gate(update, context)
+        if not can_proceed:
             return
 
         chat_id = str(update.effective_chat.id)
@@ -161,16 +403,18 @@ class TelegramService:
         username = update.effective_user.username
         message_text = update.message.text
 
-        # Send typing action
         await context.bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
 
-        # Get or create conversation
-        conversation = self.db.query(Conversation).filter(
-            Conversation.telegram_chat_id == chat_id,
-            Conversation.bot_id == self.bot.id,
-            Conversation.is_active == True
-        ).first()
-
+        # Get or create active conversation
+        conversation = (
+            self.db.query(Conversation)
+            .filter(
+                Conversation.telegram_chat_id == chat_id,
+                Conversation.bot_id == self.bot.id,
+                Conversation.is_active == True,
+            )
+            .first()
+        )
         if not conversation:
             conversation = Conversation(
                 bot_id=self.bot.id,
@@ -178,7 +422,7 @@ class TelegramService:
                 telegram_user_id=user_id,
                 telegram_username=username,
                 telegram_chat_type=update.effective_chat.type,
-                dify_user_id=f"telegram_{user_id}"
+                dify_user_id=f"telegram_{user_id}",
             )
             self.db.add(conversation)
             self.db.commit()
@@ -188,12 +432,12 @@ class TelegramService:
             conversation_id=conversation.id,
             role="user",
             content=message_text,
-            telegram_message_id=str(update.message.message_id)
+            telegram_message_id=str(update.message.message_id),
         )
         self.db.add(user_message)
         self.db.commit()
 
-        # Send message to Dify
+        # Send to Dify (streaming or blocking)
         response_text = ""
         message_id = None
         last_sent_text = None
@@ -202,56 +446,49 @@ class TelegramService:
             async for event in self.dify_service.send_message(
                     message=message_text,
                     conversation_id=conversation.dify_conversation_id,
-                    user_id=conversation.dify_user_id
+                    user_id=conversation.dify_user_id,
             ):
                 if event.get("event") == "message":
                     response_text += event.get("answer", "")
 
-                    # Update message in real-time for streaming
+                    # Real-time updates (streaming)
                     if self.bot.response_mode == "streaming":
                         if not message_id:
-                            msg = await update.message.reply_text(response_text or "...")
+                            msg = await update.message.reply_text(response_text or ".")
                             message_id = msg.message_id
                             last_sent_text = response_text or ""
                         elif len(response_text) % 20 == 0 and response_text != last_sent_text:
                             try:
                                 await context.bot.edit_message_text(
-                                    chat_id=chat_id,
-                                    message_id=message_id,
-                                    text=response_text
+                                    chat_id=chat_id, message_id=message_id, text=response_text
                                 )
                                 last_sent_text = response_text
                             except BadRequest as e:
-                                # Ignore harmless "Message is not modified"
                                 if "Message is not modified" not in str(e):
                                     raise
 
                 elif event.get("event") == "message_end":
-                    # Update conversation ID if first message
+                    # First response: capture conversation_id
                     if not conversation.dify_conversation_id:
                         conversation.dify_conversation_id = event.get("conversation_id")
 
-                    # Save assistant message
                     assistant_message = Message(
                         conversation_id=conversation.id,
                         role="assistant",
                         content=response_text,
                         dify_message_id=event.get("message_id"),
-                        tokens_used=event.get("metadata", {}).get("usage", {}).get("total_tokens")
+                        tokens_used=event.get("metadata", {}).get("usage", {}).get("total_tokens"),
                     )
                     self.db.add(assistant_message)
-
-                    # Update conversation
                     conversation.message_count += 2
                     conversation.last_message_at = datetime.utcnow()
                     self.db.commit()
 
                 elif event.get("event") == "error":
-                    error_msg = event.get("message", "An error occurred")
-                    await update.message.reply_text(f"❌ {error_msg}")
+                    await update.message.reply_text(f"❌ {event.get('message', 'An error occurred')}")
                     return
 
-            # Send final message if not streaming or update final
+            # Final flush
             if response_text:
                 if self.bot.response_mode == "blocking" or not message_id:
                     await update.message.reply_text(response_text)
@@ -259,9 +496,7 @@ class TelegramService:
                     if response_text != (last_sent_text or ""):
                         try:
                             await context.bot.edit_message_text(
-                                chat_id=chat_id,
-                                message_id=message_id,
-                                text=response_text
+                                chat_id=chat_id, message_id=message_id, text=response_text
                             )
                         except BadRequest as e:
                             if "Message is not modified" not in str(e):
@@ -270,11 +505,16 @@ class TelegramService:
                 await update.message.reply_text("I couldn't generate a response. Please try again.")
 
         except Exception as e:
-            logger.error(f"Error handling message: {str(e)}")
+            logger.error("Error handling message: %s", e)
             await update.message.reply_text("❌ An error occurred. Please try again.")
 
     async def handle_document(self, update: Update, context):
-        """Handle document uploads."""
+        """Handle document uploads (auth-gated)."""
+        # Gate uploads too
+        if self.bot.auth_required and not self._is_authenticated(str(update.effective_user.id)):
+            await update.message.reply_text("🔐 Please authenticate first: send your email.")
+            return
+
         if not self.bot.enable_file_upload:
             await update.message.reply_text("File uploads are disabled for this bot.")
             return
@@ -293,12 +533,16 @@ class TelegramService:
         username = update.effective_user.username
         caption = (update.message.caption or "").strip()
 
-        # Get or create active conversation
-        conversation = self.db.query(Conversation).filter(
-            Conversation.telegram_chat_id == chat_id,
-            Conversation.bot_id == self.bot.id,
-            Conversation.is_active == True
-        ).first()
+        # Conversation
+        conversation = (
+            self.db.query(Conversation)
+            .filter(
+                Conversation.telegram_chat_id == chat_id,
+                Conversation.bot_id == self.bot.id,
+                Conversation.is_active == True,
+            )
+            .first()
+        )
         if not conversation:
             conversation = Conversation(
                 bot_id=self.bot.id,
@@ -313,16 +557,13 @@ class TelegramService:
 
         # Upload to Dify
         result = await self.dify_service.upload_file(
-            file_data=bytes(file_data),
-            filename=document.file_name,
-            user_id=f"telegram_{user_id}"
+            file_data=bytes(file_data), filename=document.file_name, user_id=f"telegram_{user_id}"
         )
-
         if not result:
             await update.message.reply_text("❌ Failed to upload file.")
             return
 
-        # Save a user-side message (caption or a default)
+        # Save a user-side message
         user_text = caption if caption else f"[uploaded file: {document.file_name}]"
         user_message = Message(
             conversation_id=conversation.id,
@@ -334,18 +575,17 @@ class TelegramService:
         self.db.add(user_message)
         self.db.commit()
 
-        # Build Dify files payload and send the message (caption as query)
-        files_payload = [{
-            "type": "document",
-            "transfer_method": "local_file",
-            "upload_file_id": result.get("id"),
-        }]
+        files_payload = [
+            {"type": "document", "transfer_method": "local_file", "upload_file_id": result.get("id")}
+        ]
 
         query_text = caption or "Please analyze the attached file."
         await context.bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
+
         response_text = ""
         message_id = None
         last_sent_text = None
+
         try:
             async for event in self.dify_service.send_message(
                     message=query_text,
@@ -362,15 +602,18 @@ class TelegramService:
                             last_sent_text = response_text or ""
                         elif len(response_text) % 20 == 0 and response_text != last_sent_text:
                             try:
-                                await context.bot.edit_message_text(chat_id=chat_id, message_id=message_id,
-                                                                    text=response_text)
+                                await context.bot.edit_message_text(
+                                    chat_id=chat_id, message_id=message_id, text=response_text
+                                )
                                 last_sent_text = response_text
                             except BadRequest as e:
                                 if "Message is not modified" not in str(e):
                                     raise
+
                 elif event.get("event") == "message_end":
                     if not conversation.dify_conversation_id:
                         conversation.dify_conversation_id = event.get("conversation_id")
+
                     assistant_message = Message(
                         conversation_id=conversation.id,
                         role="assistant",
@@ -382,17 +625,20 @@ class TelegramService:
                     conversation.message_count += 2
                     conversation.last_message_at = datetime.utcnow()
                     self.db.commit()
+
                 elif event.get("event") == "error":
                     await update.message.reply_text(f"❌ {event.get('message', 'An error occurred')}")
                     return
+
             if response_text:
                 if self.bot.response_mode == "blocking" or not message_id:
                     await update.message.reply_text(response_text)
                 else:
                     if response_text != (last_sent_text or ""):
                         try:
-                            await context.bot.edit_message_text(chat_id=chat_id, message_id=message_id,
-                                                                text=response_text)
+                            await context.bot.edit_message_text(
+                                chat_id=chat_id, message_id=message_id, text=response_text
+                            )
                         except BadRequest as e:
                             if "Message is not modified" not in str(e):
                                 raise
@@ -402,19 +648,23 @@ class TelegramService:
             if "Message is not modified" in str(e):
                 logger.debug("Document stream noop edit ignored")
             else:
-                logger.error(f"Error handling document message: {str(e)}")
+                logger.error("Error handling document message: %s", e)
                 await update.message.reply_text("❌ An error occurred. Please try again.")
         except Exception as e:
-            logger.error(f"Error handling document message: {str(e)}")
+            logger.error("Error handling document message: %s", e)
             await update.message.reply_text("❌ An error occurred. Please try again.")
 
     async def handle_photo(self, update: Update, context):
-        """Handle photo uploads."""
+        """Handle photo uploads (auth-gated)."""
+        if self.bot.auth_required and not self._is_authenticated(str(update.effective_user.id)):
+            await update.message.reply_text("🔐 Please authenticate first: send your email.")
+            return
+
         if not self.bot.enable_file_upload:
             await update.message.reply_text("File uploads are disabled for this bot.")
             return
 
-        photo = update.message.photo[-1]  # Get highest resolution
+        photo = update.message.photo[-1]  # highest resolution
 
         # Download photo
         file = await context.bot.get_file(photo.file_id)
@@ -425,12 +675,16 @@ class TelegramService:
         username = update.effective_user.username
         caption = (update.message.caption or "").strip()
 
-        # Get or create active conversation
-        conversation = self.db.query(Conversation).filter(
-            Conversation.telegram_chat_id == chat_id,
-            Conversation.bot_id == self.bot.id,
-            Conversation.is_active == True
-        ).first()
+        # Conversation
+        conversation = (
+            self.db.query(Conversation)
+            .filter(
+                Conversation.telegram_chat_id == chat_id,
+                Conversation.bot_id == self.bot.id,
+                Conversation.is_active == True,
+            )
+            .first()
+        )
         if not conversation:
             conversation = Conversation(
                 bot_id=self.bot.id,
@@ -447,14 +701,13 @@ class TelegramService:
         result = await self.dify_service.upload_file(
             file_data=bytes(file_data),
             filename=f"photo_{photo.file_id}.jpg",
-            user_id=f"telegram_{user_id}"
+            user_id=f"telegram_{user_id}",
         )
-
         if not result:
             await update.message.reply_text("❌ Failed to upload photo.")
             return
 
-        # Save a user-side message for the caption or default text
+        # Save user-side message (caption or default)
         user_text = caption if caption else "[uploaded photo]"
         user_message = Message(
             conversation_id=conversation.id,
@@ -466,18 +719,17 @@ class TelegramService:
         self.db.add(user_message)
         self.db.commit()
 
-        # Build files payload for Dify and send message
-        files_payload = [{
-            "type": "image",
-            "transfer_method": "local_file",
-            "upload_file_id": result.get("id"),
-        }]
+        files_payload = [
+            {"type": "image", "transfer_method": "local_file", "upload_file_id": result.get("id")}
+        ]
 
         query_text = caption or "Please analyze this image."
         await context.bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
+
         response_text = ""
         message_id = None
         last_sent_text = None
+
         try:
             async for event in self.dify_service.send_message(
                     message=query_text,
@@ -494,12 +746,14 @@ class TelegramService:
                             last_sent_text = response_text or ""
                         elif len(response_text) % 20 == 0 and response_text != last_sent_text:
                             try:
-                                await context.bot.edit_message_text(chat_id=chat_id, message_id=message_id,
-                                                                    text=response_text)
+                                await context.bot.edit_message_text(
+                                    chat_id=chat_id, message_id=message_id, text=response_text
+                                )
                                 last_sent_text = response_text
                             except BadRequest as e:
                                 if "Message is not modified" not in str(e):
                                     raise
+
                 elif event.get("event") == "message_end":
                     if not conversation.dify_conversation_id:
                         conversation.dify_conversation_id = event.get("conversation_id")
@@ -514,17 +768,20 @@ class TelegramService:
                     conversation.message_count += 2
                     conversation.last_message_at = datetime.utcnow()
                     self.db.commit()
+
                 elif event.get("event") == "error":
                     await update.message.reply_text(f"❌ {event.get('message', 'An error occurred')}")
                     return
+
             if response_text:
                 if self.bot.response_mode == "blocking" or not message_id:
                     await update.message.reply_text(response_text)
                 else:
                     if response_text != (last_sent_text or ""):
                         try:
-                            await context.bot.edit_message_text(chat_id=chat_id, message_id=message_id,
-                                                                text=response_text)
+                            await context.bot.edit_message_text(
+                                chat_id=chat_id, message_id=message_id, text=response_text
+                            )
                         except BadRequest as e:
                             if "Message is not modified" not in str(e):
                                 raise
@@ -534,50 +791,8 @@ class TelegramService:
             if "Message is not modified" in str(e):
                 logger.debug("Photo stream noop edit ignored")
             else:
-                logger.error(f"Error handling photo message: {str(e)}")
+                logger.error("Error handling photo message: %s", e)
                 await update.message.reply_text("❌ An error occurred. Please try again.")
         except Exception as e:
-            logger.error(f"Error handling photo message: {str(e)}")
+            logger.error("Error handling photo message: %s", e)
             await update.message.reply_text("❌ An error occurred. Please try again.")
-
-    async def handle_clear(self, update: Update, context):
-        """Handle /clear: delete current active conversation and its messages."""
-        chat_id = str(update.effective_chat.id)
-        conv = self.db.query(Conversation).filter(
-            Conversation.telegram_chat_id == chat_id,
-            Conversation.bot_id == self.bot.id,
-            Conversation.is_active == True,
-        ).first()
-        if not conv:
-            await update.message.reply_text("Nothing to clear. You’re already fresh ✨")
-            return
-        # delete messages then conversation
-        self.db.query(Message).filter(Message.conversation_id == conv.id).delete()
-        self.db.delete(conv)
-        self.db.commit()
-        await update.message.reply_text("🧹 Cleared. Your next message will start a new conversation.")
-
-    async def handle_callback(self, update: Update, context):
-        """Handle callback queries from inline keyboards."""
-        query = update.callback_query
-        await query.answer()
-
-        if query.data.startswith("conv_"):
-            conv_id = query.data[5:]
-            conversation = self.db.query(Conversation).filter(
-                Conversation.id == conv_id
-            ).first()
-
-            if conversation:
-                # Activate this conversation
-                self.db.query(Conversation).filter(
-                    Conversation.telegram_chat_id == conversation.telegram_chat_id,
-                    Conversation.bot_id == self.bot.id
-                ).update({"is_active": False})
-
-                conversation.is_active = True
-                self.db.commit()
-
-                await query.edit_message_text(
-                    f"✅ Switched to conversation: {conversation.title or 'Untitled'}"
-                )

--- a/backend/app/utils/mailer.py
+++ b/backend/app/utils/mailer.py
@@ -1,0 +1,22 @@
+import smtplib, ssl
+from email.message import EmailMessage
+from ..core.config import settings
+
+
+def send_email(to_email: str, subject: str, body: str):
+    if not settings.SMTP_HOST:
+        raise RuntimeError("SMTP not configured")
+
+    msg = EmailMessage()
+    msg["From"] = settings.SMTP_FROM
+    msg["To"] = to_email
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    context = ssl.create_default_context()
+    with smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT) as server:
+        if settings.SMTP_STARTTLS:
+            server.starttls(context=context)
+        if settings.SMTP_USERNAME:
+            server.login(settings.SMTP_USERNAME, settings.SMTP_PASSWORD)
+        server.send_message(msg)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,13 +45,28 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      # Mailpit is optional but handy in dev for catching emails
+      mailpit:
+        condition: service_started
     environment:
+      # existing
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-plugbot}
       REDIS_URL: redis://redis:6379/0
       SECRET_KEY: ${SECRET_KEY:-plugbot-insecure-secret-change-this-in-production}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-plugbot-insecure-key-32-chars-here!!}
       BACKEND_CORS_ORIGINS: '["http://localhost:${FRONTEND_PORT:-3514}","http://frontend:3000"]'
       DEBUG: ${APP_DEBUG:-false}
+
+      # NEW: SMTP for email-based auth codes
+      # In dev with Mailpit set: SMTP_HOST=mailpit, SMTP_PORT=1025, SMTP_STARTTLS=false
+      # In prod with a real provider: set host/creds and keep SMTP_STARTTLS=true
+      SMTP_HOST: ${SMTP_HOST}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USERNAME: ${SMTP_USERNAME}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
+      SMTP_FROM: ${SMTP_FROM:-no-reply@yourdomain.com}
+      SMTP_STARTTLS: ${SMTP_STARTTLS:-true}
+
     ports:
       - "${BACKEND_PORT:-8531}:8000"
     volumes:
@@ -88,6 +103,16 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  # NEW: Local/dev SMTP sink with web UI. Open http://localhost:8025 to view OTP emails.
+  mailpit:
+    image: axllent/mailpit:latest
+    restart: unless-stopped
+    ports:
+      - "1025:1025"  # SMTP
+      - "8025:8025"  # Web UI
+    networks:
+      - plugbot-network
 
 volumes:
   postgres_data:

--- a/frontend/src/components/bots/BotForm.tsx
+++ b/frontend/src/components/bots/BotForm.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {BotCreate} from '@/types';
 import {Button} from '@/components/ui/button';
+import {Shield, Info} from 'lucide-react';
 
 interface BotFormProps {
     initialData?: Partial<BotCreate>;
@@ -10,6 +11,7 @@ interface BotFormProps {
 
 interface BotFormState {
     formData: BotCreate;
+    showAuthHelp: boolean;
 }
 
 export class BotForm extends React.Component<BotFormProps, BotFormState> {
@@ -22,12 +24,13 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
             dify_type: 'chat',
             telegram_bot_token: '',
             response_mode: 'streaming',
-            max_tokens: 2000,
-            temperature: 7,
             auto_generate_title: true,
             enable_file_upload: true,
+            auth_required: false,
+            allowed_email_domains: '',
             ...this.props.initialData,
         },
+        showAuthHelp: false,
     };
 
     handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
@@ -37,8 +40,7 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
         this.setState(prevState => ({
             formData: {
                 ...prevState.formData,
-                [name]: type === 'checkbox' ? checked :
-                    type === 'number' ? parseInt(value) : value,
+                [name]: type === 'checkbox' ? checked : value,
             },
         }));
     };
@@ -49,17 +51,17 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
     };
 
     render() {
-        const {formData} = this.state;
+        const {formData, showAuthHelp} = this.state;
         const {onCancel} = this.props;
 
         return (
             <form onSubmit={this.handleSubmit} className="space-y-6">
                 {/* Basic Information */}
                 <div className="space-y-4">
-                    <h3 className="text-lg font-medium">Basic Information</h3>
+                    <h3 className="text-lg font-semibold text-gray-900">Basic Information</h3>
 
                     <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
                             Bot Name *
                         </label>
                         <input
@@ -68,13 +70,13 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
                             value={formData.name}
                             onChange={this.handleChange}
                             required
-                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                             placeholder="My Dify Bot"
                         />
                     </div>
 
                     <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
                             Description
                         </label>
                         <textarea
@@ -82,7 +84,7 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
                             value={formData.description}
                             onChange={this.handleChange}
                             rows={3}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all resize-none"
                             placeholder="A helpful AI assistant powered by Dify"
                         />
                     </div>
@@ -90,10 +92,10 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
 
                 {/* Dify Configuration */}
                 <div className="space-y-4">
-                    <h3 className="text-lg font-medium">Dify Configuration</h3>
+                    <h3 className="text-lg font-semibold text-gray-900">Dify Configuration</h3>
 
                     <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
                             Dify Endpoint *
                         </label>
                         <input
@@ -102,13 +104,13 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
                             value={formData.dify_endpoint}
                             onChange={this.handleChange}
                             required
-                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                             placeholder="http://agents.algolyzerlab.com/v1"
                         />
                     </div>
 
                     <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
                             Dify API Key *
                         </label>
                         <input
@@ -117,21 +119,21 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
                             value={formData.dify_api_key}
                             onChange={this.handleChange}
                             required={!this.props.initialData}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                             placeholder="app-xxxxxxxxxxxxx"
                         />
                     </div>
 
                     <div className="grid grid-cols-2 gap-4">
                         <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">
+                            <label className="block text-sm font-medium text-gray-700 mb-2">
                                 Dify Type
                             </label>
                             <select
                                 name="dify_type"
                                 value={formData.dify_type}
                                 onChange={this.handleChange}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                             >
                                 <option value="chat">Chat</option>
                                 <option value="agent">Agent</option>
@@ -141,14 +143,14 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
                         </div>
 
                         <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">
+                            <label className="block text-sm font-medium text-gray-700 mb-2">
                                 Response Mode
                             </label>
                             <select
                                 name="response_mode"
                                 value={formData.response_mode}
                                 onChange={this.handleChange}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                             >
                                 <option value="streaming">Streaming</option>
                                 <option value="blocking">Blocking</option>
@@ -159,10 +161,10 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
 
                 {/* Telegram Configuration */}
                 <div className="space-y-4">
-                    <h3 className="text-lg font-medium">Telegram Configuration</h3>
+                    <h3 className="text-lg font-semibold text-gray-900">Telegram Configuration</h3>
 
                     <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
                             Telegram Bot Token (Optional)
                         </label>
                         <input
@@ -170,10 +172,10 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
                             name="telegram_bot_token"
                             value={formData.telegram_bot_token}
                             onChange={this.handleChange}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                             placeholder="1234567890:ABCdefGHIjklMNOpqrsTUVwxyz"
                         />
-                        <p className="mt-1 text-sm text-gray-500">
+                        <p className="mt-2 text-sm text-gray-500">
                             Get your bot token from @BotFather on Telegram
                         </p>
                     </div>
@@ -181,71 +183,102 @@ export class BotForm extends React.Component<BotFormProps, BotFormState> {
 
                 {/* Advanced Settings */}
                 <div className="space-y-4">
-                    <h3 className="text-lg font-medium">Advanced Settings</h3>
+                    <h3 className="text-lg font-semibold text-gray-900">Advanced Settings</h3>
 
-                    <div className="grid grid-cols-2 gap-4">
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">
-                                Max Tokens
-                            </label>
-                            <input
-                                type="number"
-                                name="max_tokens"
-                                value={formData.max_tokens}
-                                onChange={this.handleChange}
-                                min={100}
-                                max={10000}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                            />
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-1">
-                                Temperature (0-10)
-                            </label>
-                            <input
-                                type="number"
-                                name="temperature"
-                                value={formData.temperature}
-                                onChange={this.handleChange}
-                                min={0}
-                                max={10}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                            />
-                        </div>
-                    </div>
-
-                    <div className="space-y-2">
-                        <label className="flex items-center space-x-2">
+                    <div className="space-y-3">
+                        <label className="flex items-center space-x-3 cursor-pointer">
                             <input
                                 type="checkbox"
                                 name="auto_generate_title"
                                 checked={formData.auto_generate_title}
                                 onChange={this.handleChange}
-                                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                                className="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500"
                             />
                             <span className="text-sm font-medium text-gray-700">
-                Auto-generate conversation titles
-              </span>
+                                Auto-generate conversation titles
+                            </span>
                         </label>
 
-                        <label className="flex items-center space-x-2">
+                        <label className="flex items-center space-x-3 cursor-pointer">
                             <input
                                 type="checkbox"
                                 name="enable_file_upload"
                                 checked={formData.enable_file_upload}
                                 onChange={this.handleChange}
-                                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                                className="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500"
                             />
                             <span className="text-sm font-medium text-gray-700">
-                Enable file uploads
-              </span>
+                                Enable file uploads
+                            </span>
                         </label>
                     </div>
                 </div>
 
+                {/* Authentication Settings */}
+                <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                        <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+                            <Shield className="h-5 w-5 text-blue-600"/>
+                            Authentication Settings
+                        </h3>
+                        <button
+                            type="button"
+                            onClick={() => this.setState({showAuthHelp: !showAuthHelp})}
+                            className="text-blue-600 hover:text-blue-700"
+                        >
+                            <Info className="h-5 w-5"/>
+                        </button>
+                    </div>
+
+                    {showAuthHelp && (
+                        <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                            <p className="text-sm text-blue-800">
+                                When authentication is enabled, users must verify their email address before they can
+                                use the bot.
+                                Only users with email addresses from the specified domains will be allowed to
+                                authenticate.
+                                Users will receive a verification code via email and must enter it in Telegram to gain
+                                access.
+                            </p>
+                        </div>
+                    )}
+
+                    <label className="flex items-center space-x-3 cursor-pointer">
+                        <input
+                            type="checkbox"
+                            name="auth_required"
+                            checked={formData.auth_required}
+                            onChange={this.handleChange}
+                            className="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500"
+                        />
+                        <span className="text-sm font-medium text-gray-700">
+                            Require email authentication
+                        </span>
+                    </label>
+
+                    {formData.auth_required && (
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-2">
+                                Allowed Email Domains
+                            </label>
+                            <input
+                                type="text"
+                                name="allowed_email_domains"
+                                value={formData.allowed_email_domains}
+                                onChange={this.handleChange}
+                                className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                                placeholder="algolyzer.com, google.com"
+                            />
+                            <p className="mt-2 text-sm text-gray-500">
+                                Enter comma-separated domain names (e.g., algolyzer.com, google.com).
+                                Only users with email addresses from these domains can authenticate.
+                            </p>
+                        </div>
+                    )}
+                </div>
+
                 {/* Actions */}
-                <div className="flex justify-end space-x-3 pt-4 border-t">
+                <div className="flex justify-end space-x-3 pt-6 border-t">
                     <Button type="button" variant="secondary" onClick={onCancel}>
                         Cancel
                     </Button>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,8 +5,6 @@ export interface Bot {
     dify_endpoint: string;
     dify_type: 'chat' | 'agent' | 'chatflow' | 'workflow';
     response_mode: 'streaming' | 'blocking';
-    max_tokens: number;
-    temperature: number;
     auto_generate_title: boolean;
     enable_file_upload: boolean;
     is_active: boolean;
@@ -15,6 +13,8 @@ export interface Bot {
     telegram_bot_token?: string;
     last_health_check?: string;
     health_status: 'healthy' | 'unhealthy' | 'unknown';
+    auth_required: boolean;
+    allowed_email_domains?: string;
     created_at: string;
     updated_at?: string;
 }
@@ -27,10 +27,10 @@ export interface BotCreate {
     dify_type: 'chat' | 'agent' | 'chatflow' | 'workflow';
     telegram_bot_token?: string;
     response_mode: 'streaming' | 'blocking';
-    max_tokens: number;
-    temperature: number;
     auto_generate_title: boolean;
     enable_file_upload: boolean;
+    auth_required: boolean;
+    allowed_email_domains?: string;
 }
 
 export interface BotStatus {


### PR DESCRIPTION
**Description:**
Adds optional email-based OTP authentication to Telegram bots.

* Blocks messages until email is verified
* Restricts by allowed domains
* Sends 6-digit code via SMTP (5-min expiry)
* `/logout` to revoke access
* Uses Redis for session tracking

Infra updates:

* New `mailer.py` SMTP utility
* SMTP env vars in config & `.env.example`
* Mailpit service in `docker-compose.yml` for local testing

Dev test: set `SMTP_HOST=mailpit`, open `http://localhost:8025` to view OTP emails.
Prod: configure with real SMTP provider creds.
