### PR TITLE
fix: block OTP message from triggering conversation after auth

### DIFF
--- a/backend/app/services/telegram_service.py
+++ b/backend/app/services/telegram_service.py
@@ -337,7 +337,7 @@ class TelegramService:
                 self._set_authenticated(user_id, code_row.email)
                 self.redis.delete(self._pending_key(user_id))
                 await update.message.reply_text("✅ Authentication successful! You can now chat.")
-                return True
+                return False
             else:
                 await update.message.reply_text(
                     "❌ Invalid or expired code. Please send your email again."


### PR DESCRIPTION
## **Description**

### **Problem**

When a user logs in to the Telegram bot using an email verification code (OTP), the code is processed to authenticate them, **but the same message** was also forwarded to Dify as normal chat input.
This caused:

* The bot replying to the OTP message as if it were part of the conversation.
* Confusion for users, since they received a “normal” bot reply to their verification code.

### **Solution**

* Modified `_auth_gate` so that after a **successful OTP validation**, it **returns `False`**.
* This prevents the current OTP message from continuing through the message handler pipeline to Dify.
* The **next** user message (after authentication) will start the conversation normally.

### **Changes Made**

* In `telegram_service.py` inside `_auth_gate`:

  * After confirming authentication, replaced `return True` with `return False`.

### **Why This Works**

* `handle_message` already checks:

  ```python
  can_proceed = await self._auth_gate(update, context)
  if not can_proceed:
      return
  ```

  Returning `False` immediately stops further processing for that update.
* No changes to Redis auth storage, DB updates, or conversation flow were needed.

### **Testing**

* **Before fix:**

  1. Start bot → request email code.
  2. Enter valid code.
  3. Bot replies "✅ Authentication successful!" **and** sends code text to Dify.
* **After fix:**

  1. Start bot → request email code.
  2. Enter valid code.
  3. Bot replies "✅ Authentication successful!" only.
  4. Next user message starts Dify conversation normally.

### **Impact**

* Prevents OTP from leaking into conversation history.
* Improves onboarding flow and avoids confusing first-time users.
* No impact on already-authenticated users or file upload handling.