### PR TITLE
Add Telegram HTML Markdown formatter utility

### DIFF
--- a/backend/alembic/versions/006_add_markdown_flag.py
+++ b/backend/alembic/versions/006_add_markdown_flag.py
@@ -1,0 +1,25 @@
+# backend/alembic/versions/006_add_markdown_flag.py
+"""add telegram_markdown_enabled to bots
+
+Revision ID: 006
+Revises: 005
+Create Date: 2025-08-09 12:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "006"
+down_revision = "005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "bots",
+        sa.Column("telegram_markdown_enabled", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_column("bots", "telegram_markdown_enabled")

--- a/backend/app/models/bot.py
+++ b/backend/app/models/bot.py
@@ -24,6 +24,9 @@ class Bot(Base):
     telegram_bot_username = Column(String(255))
     telegram_webhook_secret = Column(String(255))
 
+    # Markdown
+    telegram_markdown_enabled = Column(Boolean, default=False)
+
     # Status
     is_active = Column(Boolean, default=True)
     is_telegram_connected = Column(Boolean, default=False)

--- a/backend/app/schemas/bot.py
+++ b/backend/app/schemas/bot.py
@@ -12,6 +12,7 @@ class BotBase(BaseModel):
     response_mode: str = Field(default="streaming", pattern="^(streaming|blocking)$")
     auto_generate_title: bool = True
     enable_file_upload: bool = True
+    telegram_markdown_enabled: bool = False
 
     # Authentication settings
     auth_required: bool = False
@@ -74,6 +75,7 @@ class BotUpdate(BaseModel):
     is_active: Optional[bool] = None
     auth_required: Optional[bool] = None
     allowed_email_domains: Optional[str] = None
+    telegram_markdown_enabled: Optional[bool] = None
 
     @field_validator('dify_endpoint')
     def normalize_endpoint(cls, v: Optional[str]):

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,6 +7,7 @@ export interface Bot {
     response_mode: 'streaming' | 'blocking';
     auto_generate_title: boolean;
     enable_file_upload: boolean;
+    telegram_markdown_enabled: boolean;
     is_active: boolean;
     is_telegram_connected: boolean;
     telegram_bot_username?: string;
@@ -29,6 +30,7 @@ export interface BotCreate {
     response_mode: 'streaming' | 'blocking';
     auto_generate_title: boolean;
     enable_file_upload: boolean;
+    telegram_markdown_enabled: boolean;
     auth_required: boolean;
     allowed_email_domains?: string;
 }


### PR DESCRIPTION
**Summary:**
This PR to cleanly convert a safe subset of Markdown to Telegram-supported HTML. It centralizes all Telegram formatting logic in one file and replaces the old inline escaping with a reusable formatter.

**Details:**

  * Supports **bold**, *italic*, `inline code`, fenced code blocks, links, lists, and tables (as `<pre>` blocks)
  * Escapes unsafe characters for HTML output to avoid Telegram parse errors
  * Strips or downgrades unsupported Markdown syntax so messages never fail to send
* Exposes `format_for_telegram()`
