### PR TITLE
feat: add user profile management, admin settings UI, and backend support

### DIFF
--- a/backend/alembic/versions/007_add_app_settings.py
+++ b/backend/alembic/versions/007_add_app_settings.py
@@ -1,0 +1,28 @@
+"""add app_settings table"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "007"
+down_revision = "006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "app_settings",
+        sa.Column("id", sa.String(), primary_key=True, nullable=False),
+        sa.Column("project_name", sa.String(255), nullable=False),
+        sa.Column("allow_registration", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # optional: seed a single row named 'global'
+    op.execute(
+        "INSERT INTO app_settings (id, project_name, allow_registration) VALUES "
+        "('global', 'PlugBot', false)"
+    )
+
+
+def downgrade():
+    op.drop_table("app_settings")

--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from ...api.deps import get_db, get_current_superuser
+from ...schemas.settings import SettingsResponse, SettingsUpdate
+from ...services.settings_service import settings_service
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.get("/settings", response_model=SettingsResponse)
+async def get_settings(db: Session = Depends(get_db), _: str = Depends(get_current_superuser)):
+    return settings_service.get(db)
+
+
+@router.put("/settings", response_model=SettingsResponse)
+async def update_settings(
+        payload: SettingsUpdate,
+        db: Session = Depends(get_db),
+        _: str = Depends(get_current_superuser),
+):
+    return settings_service.update(db, **payload.dict(exclude_unset=True))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from contextlib import asynccontextmanager
 from .core.config import settings
 from .core.database import Base, db_manager
-from .api.v1 import bots, conversations, webhooks, auth
+from .api.v1 import bots, conversations, webhooks, auth, admin as admin_router
 from .services.bot_manager import bot_manager
 from .models.bot import Bot
 from .utils.logger import get_logger
@@ -143,6 +143,7 @@ app.include_router(bots.router, prefix=settings.API_V1_STR)
 app.include_router(conversations.router, prefix=settings.API_V1_STR)
 app.include_router(webhooks.router, prefix=settings.API_V1_STR)
 app.include_router(auth.router, prefix=settings.API_V1_STR)
+app.include_router(admin_router.router, prefix=settings.API_V1_STR)
 
 
 # Root endpoint

--- a/backend/app/models/app_setting.py
+++ b/backend/app/models/app_setting.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, String, Boolean, DateTime
+from sqlalchemy.sql import func
+from ..core.database import Base
+
+
+class AppSetting(Base):
+    __tablename__ = "app_settings"
+    id = Column(String, primary_key=True)  # use 'global'
+    project_name = Column(String(255), nullable=False)
+    allow_registration = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class SettingsResponse(BaseModel):
+    project_name: str
+    allow_registration: bool
+
+    class Config: from_attributes = True
+
+
+class SettingsUpdate(BaseModel):
+    project_name: Optional[str] = None
+    allow_registration: Optional[bool] = None

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, Field, field_validator
+from typing import Optional
+import re
+
+
+class UserUpdate(BaseModel):
+    username: Optional[str] = Field(None, min_length=3, max_length=50)
+    full_name: Optional[str] = Field(None, max_length=255)
+
+    @field_validator('username')
+    @classmethod
+    def validate_username(cls, v):
+        if v is None:
+            return v
+        if not re.match(r'^[a-zA-Z0-9_-]+$', v):
+            raise ValueError('Username can only contain letters, numbers, underscores and hyphens')
+        return v.lower()
+
+
+class PasswordChange(BaseModel):
+    current_password: str
+    new_password: str = Field(..., min_length=8, max_length=100)

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -1,0 +1,31 @@
+from sqlalchemy.orm import Session
+from ..models.app_setting import AppSetting
+from ..core.config import settings
+
+
+class SettingsService:
+    def get(self, db: Session) -> AppSetting:
+        row = db.query(AppSetting).first()
+        if not row:
+            row = AppSetting(
+                id="global",
+                project_name=settings.PROJECT_NAME,
+                allow_registration=settings.ALLOW_REGISTRATION,
+            )
+            db.add(row);
+            db.commit();
+            db.refresh(row)
+        return row
+
+    def update(self, db: Session, *, project_name=None, allow_registration=None) -> AppSetting:
+        row = self.get(db)
+        if project_name is not None:
+            row.project_name = project_name
+        if allow_registration is not None:
+            row.allow_registration = allow_registration
+        db.commit();
+        db.refresh(row)
+        return row
+
+
+settings_service = SettingsService()

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,15 @@
-FROM node:18-alpine AS deps
-RUN apk add --no-cache libc6-compat
+FROM node:20-alpine3.20 AS deps
+RUN apk update && apk add --no-cache libc6-compat
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
-FROM node:18-alpine AS builder
-# CRITICAL: Accept build argument and set as environment variable
+# Use the same base for other stages
+FROM node:20-alpine3.20 AS builder
+# Optional but handy if any native deps compile during build
+RUN apk update && apk add --no-cache libc6-compat
+
+# Accept build argument and set as environment variable
 ARG NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 
@@ -19,14 +23,17 @@ COPY . .
 # Build the application with the environment variable
 RUN npm run build
 
-FROM node:18-alpine AS runner
+FROM node:20-alpine3.20 AS runner
+# Runtime libc compatibility in case native modules need it
+RUN apk update && apk add --no-cache libc6-compat
+
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+RUN addgroup --system --gid 1001 nodejs \
+  && adduser --system --uid 1001 nextjs
 
 # Copy public folder
 COPY --from=builder /app/public ./public
@@ -39,6 +46,6 @@ USER nextjs
 
 EXPOSE 3000
 ENV PORT=3000
-ENV HOSTNAME="0.0.0.0"
+ENV HOSTNAME=0.0.0.0
 
 CMD ["node", "server.js"]

--- a/frontend/src/app/[locale]/account/page.tsx
+++ b/frontend/src/app/[locale]/account/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import React, {useEffect, useState} from 'react';
+import {useLocale} from 'next-intl';
+import ProtectedRoute from '@/components/ProtectedRoute';
+import {useAuth} from '@/contexts/AuthContext';
+import {apiClient} from '@/lib/api/client';
+import {Lock, Save, User as UserIcon, ShieldCheck} from 'lucide-react';
+
+export default function AccountPage() {
+    const {user} = useAuth();
+    const locale = useLocale();
+
+    // Profile form state
+    const [username, setUsername] = useState('');
+    const [fullName, setFullName] = useState('');
+    const [savingProfile, setSavingProfile] = useState(false);
+    const [profileMsg, setProfileMsg] = useState<string | null>(null);
+
+    // Password form state
+    const [currentPassword, setCurrentPassword] = useState('');
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmNewPassword, setConfirmNewPassword] = useState('');
+    const [changingPw, setChangingPw] = useState(false);
+    const [pwMsg, setPwMsg] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (user) {
+            setUsername(user.username || '');
+            setFullName(user.full_name || '');
+        }
+    }, [user]);
+
+    const handleSaveProfile = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setProfileMsg(null);
+        setSavingProfile(true);
+        try {
+            await apiClient.updateProfile({username, full_name: fullName || undefined});
+            setProfileMsg('Profile updated');
+        } catch (err: any) {
+            setProfileMsg(err?.message || 'Failed to update profile');
+        } finally {
+            setSavingProfile(false);
+        }
+    };
+
+    const handleChangePassword = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setPwMsg(null);
+
+        if (newPassword !== confirmNewPassword) {
+            setPwMsg('New passwords do not match');
+            return;
+        }
+
+        setChangingPw(true);
+        try {
+            await apiClient.changePassword({current_password: currentPassword, new_password: newPassword});
+            setPwMsg('Password changed');
+            setCurrentPassword('');
+            setNewPassword('');
+            setConfirmNewPassword('');
+        } catch (err: any) {
+            setPwMsg(err?.message || 'Failed to change password');
+        } finally {
+            setChangingPw(false);
+        }
+    };
+
+    return (
+        <ProtectedRoute>
+            <div className="max-w-3xl mx-auto px-4 py-10">
+                <div className="mb-8">
+                    <h1 className="text-2xl font-bold">Account</h1>
+                    <p className="text-gray-600">Manage your profile and password.</p>
+                </div>
+
+                <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+                    {/* Profile */}
+                    <div className="bg-white rounded-2xl shadow-sm border p-6">
+                        <div className="flex items-center gap-2 mb-4">
+                            <UserIcon className="w-5 h-5"/>
+                            <h2 className="font-semibold">Profile</h2>
+                        </div>
+                        {profileMsg && (
+                            <div
+                                className="mb-4 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                                {profileMsg}
+                            </div>
+                        )}
+                        <form onSubmit={handleSaveProfile} className="space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Username</label>
+                                <input
+                                    value={username}
+                                    onChange={(e) => setUsername(e.target.value)}
+                                    required
+                                    pattern="^[a-zA-Z0-9_-]+$"
+                                    className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                    placeholder="your_username"
+                                    autoComplete="username"
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Full name</label>
+                                <input
+                                    value={fullName}
+                                    onChange={(e) => setFullName(e.target.value)}
+                                    className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                    placeholder="Your name (optional)"
+                                    autoComplete="name"
+                                />
+                            </div>
+                            <button
+                                type="submit"
+                                disabled={savingProfile}
+                                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+                            >
+                                <Save className="w-4 h-4"/> Save
+                            </button>
+                        </form>
+                    </div>
+
+                    {/* Change Password */}
+                    <div className="bg-white rounded-2xl shadow-sm border p-6">
+                        <div className="flex items-center gap-2 mb-4">
+                            <Lock className="w-5 h-5"/>
+                            <h2 className="font-semibold">Change password</h2>
+                        </div>
+                        {pwMsg && (
+                            <div
+                                className={`mb-4 text-sm rounded-lg px-3 py-2 ${pwMsg.includes('changed') ? 'bg-green-50 text-green-700 border border-green-200' : 'bg-red-50 text-red-700 border border-red-200'}`}>
+                                {pwMsg}
+                            </div>
+                        )}
+                        <form onSubmit={handleChangePassword} className="space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Current password</label>
+                                <input
+                                    type="password"
+                                    value={currentPassword}
+                                    onChange={(e) => setCurrentPassword(e.target.value)}
+                                    required
+                                    className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                    autoComplete="current-password"
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">New password</label>
+                                <input
+                                    type="password"
+                                    value={newPassword}
+                                    onChange={(e) => setNewPassword(e.target.value)}
+                                    required
+                                    minLength={8}
+                                    className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                    autoComplete="new-password"
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Confirm new
+                                    password</label>
+                                <input
+                                    type="password"
+                                    value={confirmNewPassword}
+                                    onChange={(e) => setConfirmNewPassword(e.target.value)}
+                                    required
+                                    className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                    autoComplete="new-password"
+                                />
+                            </div>
+                            <button
+                                type="submit"
+                                disabled={changingPw}
+                                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+                            >
+                                <ShieldCheck className="w-4 h-4"/> Update password
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </ProtectedRoute>
+    );
+}

--- a/frontend/src/app/[locale]/admin/settings/page.tsx
+++ b/frontend/src/app/[locale]/admin/settings/page.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import React, {useEffect, useState} from 'react';
+import {useLocale} from 'next-intl';
+import ProtectedRoute from '@/components/ProtectedRoute';
+import {useAuth} from '@/contexts/AuthContext';
+import {apiClient} from '@/lib/api/client';
+import {Settings, Save} from 'lucide-react';
+
+export default function AdminSettingsPage() {
+    const {user} = useAuth();
+    const locale = useLocale();
+
+    const [form, setForm] = useState({project_name: '', allow_registration: false});
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [msg, setMsg] = useState<string | null>(null);
+
+    useEffect(() => {
+        let mounted = true;
+        (async () => {
+            try {
+                const s = await apiClient.getSettings();
+                if (mounted) setForm({project_name: s.project_name ?? '', allow_registration: !!s.allow_registration});
+            } catch (e: any) {
+                setMsg(e?.message || 'Failed to load settings');
+            } finally {
+                setLoading(false);
+            }
+        })();
+        return () => {
+            mounted = false;
+        };
+    }, []);
+
+    const onSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setMsg(null);
+        setSaving(true);
+        try {
+            await apiClient.updateSettings(form);
+            setMsg('Settings saved');
+        } catch (e: any) {
+            setMsg(e?.message || 'Failed to save settings');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <ProtectedRoute>
+            <div className="max-w-3xl mx-auto px-4 py-10">
+                <div className="mb-8">
+                    <h1 className="text-2xl font-bold">Admin settings</h1>
+                    <p className="text-gray-600">Rename PlugBot and control registration.</p>
+                </div>
+
+                {!user?.is_superuser ? (
+                    <div className="bg-red-50 border border-red-200 text-red-700 rounded-xl p-4">
+                        You do not have permission to view this page.
+                    </div>
+                ) : (
+                    <div className="bg-white rounded-2xl shadow-sm border p-6">
+                        <div className="flex items-center gap-2 mb-4">
+                            <Settings className="w-5 h-5"/>
+                            <h2 className="font-semibold">General</h2>
+                        </div>
+
+                        {msg && (
+                            <div
+                                className={`mb-4 text-sm rounded-lg px-3 py-2 ${msg.includes('saved') ? 'bg-green-50 text-green-700 border border-green-200' : 'bg-red-50 text-red-700 border border-red-200'}`}>
+                                {msg}
+                            </div>
+                        )}
+
+                        <form onSubmit={onSubmit} className="space-y-6">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Project name</label>
+                                <input
+                                    value={form.project_name}
+                                    onChange={(e) => setForm((f) => ({...f, project_name: e.target.value}))}
+                                    placeholder="e.g. My Awesome Bot"
+                                    className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                />
+                                <p className="text-xs text-gray-500 mt-1">Shown in the navbar and meta.</p>
+                            </div>
+
+                            <div className="flex items-center gap-3">
+                                <input
+                                    id="allow_reg"
+                                    type="checkbox"
+                                    checked={form.allow_registration}
+                                    onChange={(e) => setForm((f) => ({...f, allow_registration: e.target.checked}))}
+                                    className="h-4 w-4"
+                                />
+                                <label htmlFor="allow_reg" className="text-sm text-gray-800">Allow user
+                                    registration</label>
+                            </div>
+
+                            <button
+                                type="submit"
+                                disabled={saving}
+                                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+                            >
+                                <Save className="w-4 h-4"/> Save settings
+                            </button>
+                        </form>
+                    </div>
+                )}
+            </div>
+        </ProtectedRoute>
+    );
+}
+

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -4,7 +4,7 @@ import {useAuth} from '@/contexts/AuthContext';
 import {useTranslations, useLocale} from 'next-intl';
 import Link from 'next/link';
 import {usePathname} from 'next/navigation';
-import {LogOut, User} from 'lucide-react';
+import {LogOut, User, Settings as Cog, Shield} from 'lucide-react';
 import LanguageSwitcher from './LanguageSwitcher';
 
 export default function Navigation() {
@@ -14,25 +14,28 @@ export default function Navigation() {
     const locale = useLocale();
 
     // Don't show navigation on auth pages
-    if (pathname.includes('/auth')) {
-        return null;
-    }
-
-    if (!user) {
-        return null;
-    }
+    if (pathname.includes('/auth')) return null;
+    if (!user) return null;
 
     return (
         <nav className="bg-white shadow-sm border-b">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="flex justify-between h-16">
-                    <div className="flex items-center">
-                        <Link
-                            href={`/${locale}/dashboard`}
-                            className="text-xl font-bold text-gray-900"
-                        >
+                    <div className="flex items-center gap-6">
+                        <Link href={`/${locale}/dashboard`} className="text-xl font-bold text-gray-900">
                             {t('title')}
                         </Link>
+                        {/* New: quick links */}
+                        <Link href={`/${locale}/account`}
+                              className="text-sm text-gray-700 hover:text-gray-900 inline-flex items-center gap-1">
+                            <User className="w-4 h-4"/> Account
+                        </Link>
+                        {user.is_superuser && (
+                            <Link href={`/${locale}/admin/settings`}
+                                  className="text-sm text-gray-700 hover:text-gray-900 inline-flex items-center gap-1">
+                                <Cog className="w-4 h-4"/> Admin
+                            </Link>
+                        )}
                     </div>
 
                     <div className="flex items-center space-x-4">

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -10,9 +10,7 @@ class ApiClient {
         // - Keep HTTP for localhost regardless of page protocol
         // - Use HTTPS for production domains when page is HTTPS
         if (typeof window !== 'undefined') {
-            const isLocalhost =
-                apiUrl.includes('localhost') ||
-                apiUrl.includes('127.0.0.1');
+            const isLocalhost = apiUrl.includes('localhost') || apiUrl.includes('127.0.0.1');
             const pageIsHttps = window.location.protocol === 'https:';
 
             if (pageIsHttps && !isLocalhost) {
@@ -59,7 +57,7 @@ class ApiClient {
                 ...options?.headers,
             },
             // Use 'same-origin' for localhost, 'include' for cross-origin
-            credentials: this.baseUrl.includes('localhost') ? 'same-origin' : 'include',
+            credentials: this.baseUrl.includes('localhost') ? 'same-origin' : ('include' as RequestCredentials),
         });
 
         if (!response.ok) {
@@ -118,8 +116,23 @@ class ApiClient {
             method: 'POST',
             body: JSON.stringify({
                 token,
-                new_password: newPassword
-            })
+                new_password: newPassword,
+            }),
+        });
+    }
+
+    // --- New: profile & password management ---
+    async updateProfile(data: { username?: string; full_name?: string }): Promise<any> {
+        return this.request('/auth/me', {
+            method: 'PATCH',
+            body: JSON.stringify(data),
+        });
+    }
+
+    async changePassword(data: { current_password: string; new_password: string }): Promise<any> {
+        return this.request('/auth/change-password', {
+            method: 'POST',
+            body: JSON.stringify(data),
         });
     }
 
@@ -184,6 +197,18 @@ class ApiClient {
     async getConversations(botId?: string): Promise<Conversation[]> {
         const params = botId ? `?bot_id=${encodeURIComponent(botId)}` : '';
         return this.request<Conversation[]>(`/conversations${params}`);
+    }
+
+    // ===== Admin / Settings endpoints =====
+    async getSettings(): Promise<any> {
+        return this.request('/admin/settings');
+    }
+
+    async updateSettings(data: { project_name?: string; allow_registration?: boolean }): Promise<any> {
+        return this.request('/admin/settings', {
+            method: 'PUT',
+            body: JSON.stringify(data),
+        });
     }
 }
 


### PR DESCRIPTION
**Summary**
Adds profile editing, password change, brand rename, and registration toggle. Includes backend APIs, DB migration, frontend pages, and navigation updates.

**Changes**

* **Backend**

  * New schemas, service methods, and endpoints for profile & password change
  * `app_settings` table, model, service, and admin routes
  * Registration uses DB `allow_registration` flag
* **Frontend**

  * `/account` page: profile + password forms
  * `/admin/settings` page: brand & registration toggle (superusers only)
  * Nav links for Account/Admin
  * API client methods for new endpoints
  * Dockerfile fix for Alpine/libc6-compat

**Testing**

* Migrate DB → `alembic upgrade head`
* Test `/account` as normal user
* Test `/admin/settings` as superuser
* Verify registration toggle works
